### PR TITLE
feat: Log errors to `stderr`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,7 @@ function getPackageDetails(name) {
     })
     .then(mapResponseToPackage)
     .catch(err => {
-      console.log('Could not fetch package details!');
+      console.error('Could not fetch package details:', name, err);
     });
 }
 
@@ -133,7 +133,7 @@ function init() {
   Promise.all(packageNames.map(getPackageDetails))
     .then(printTable)
     .catch(err => {
-      console.log('Oops, looks like the comparison failed');
+      console.error('Oops, looks like the comparison failed', err);
     });
 }
 


### PR DESCRIPTION
- Using `console.error` instead of `console.log` allows to pipe the result into a file
- Logging the error itself (and package name when available) provides more information