### PR TITLE
feat: Sanitize package name arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,11 @@
         }
       }
     },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+    },
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
@@ -368,6 +373,14 @@
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "requires": {
         "has-flag": "^2.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "requires": {
+        "builtins": "^1.0.3"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chalk": "^2.3.0",
     "cli-table3": "^0.5.0",
     "date-fns": "^1.28.0",
+    "validate-npm-package-name": "^3.0.0",
     "yargs": "^10.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@ axios@^0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
@@ -302,6 +307,13 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+  dependencies:
+    builtins "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
My initial issue was that I wanted to be able to write `npm-compare */` which in bash would pass the list of all subdirectories to the tool, but all end with a `/`.
By doing that the tool still made all those API requests to npms.io, which I think we can avoid.
So with this change npm-compare tries to
- considers all white space in arguments as separators (multiple as a single one) between package names (since whitespace is not allowed in npm package names)
- removes some invalid chars from beginning and end of arguments (including `/` and `\` from directory list)
- filters the result using `validate-npm-package-name` and reports the skipped ones to stderr (incl the reason that lib provides)

I ran both `yarn add validate-npm-package-name` and `npm i validate-npm-package-name` to update both lockfiles.

https://github.com/npm/validate-npm-package-name
https://github.com/sanchitnevgi/npm-compare/issues/14